### PR TITLE
Fix CSV last column empty bug

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+tests/fixtures

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@types/node": "14.0.9",
     "@types/table": "5.0.0",
+    "@types/tmp": "^0.2.3",
     "@types/yargs": "15.0.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
@@ -47,6 +48,7 @@
     "prettier": "2.0.5",
     "pretty-quick": "2.0.1",
     "rimraf": "3.0.2",
+    "tmp": "^0.2.1",
     "ts-node": "8.10.2",
     "typescript": "3.9.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nocuous",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A static code analysis tool for JavaScript and TypeScript.",
   "main": "index.js",
   "bin": {

--- a/src/reports/csv.ts
+++ b/src/reports/csv.ts
@@ -39,7 +39,7 @@ export function report(
       }
     }
     row.unshift(`"${path}"`);
-    row.length = headers.length;
+    row.length = headers.length + 1; // headers do not have "Path"
     rows.push(row.join(","));
   }
   const titles = headers.map((h) => `"${labels[h]}"`);

--- a/tests/fixtures/stats/cyclomaticComplexity.ts
+++ b/tests/fixtures/stats/cyclomaticComplexity.ts
@@ -41,3 +41,24 @@ export function qux(a: string, b: string): string | number {
   }
   return 0;
 }
+
+export function foo(a: number) {
+  for (let i = 0; false; i++) { } // FoStatement without added complexity
+  for (let i = 0; i < 10; i++) { }// FoStatement with added complexity
+  while (false) { }; // WhileStatement with no added complexity
+  while (a < 5) { // WhileStatement with added complexity
+    do { a++ } while (a < 5); // DoStatement
+  };
+  try {} catch {}; // CatchClause
+  a = a < 0 ? 0 : a; // ConditionalExpression
+  for (let x in []) {}; // ForInStatement
+  for (let x of []) {}; // ForOfStatement
+  function bar() {}; // FunctionDeclaration
+  const baz = function() {}; // FunctionExpression
+  const obj = {
+    foo() {}, // MethodDeclaration
+    get bar() { return null }, // GetAccessor
+    set bar(val) {}, // SetAccessor
+  };
+  const Quux = class {}; // ClassExpression
+};

--- a/tests/unit/reports/csv.ts
+++ b/tests/unit/reports/csv.ts
@@ -1,0 +1,23 @@
+import test from "ava";
+import { fixtureAsSourceFile } from "../../util";
+import { stat } from "../../../src/stats/anonInnerLength";
+import { report } from "../../../src/reports/csv";
+import { StatResults } from "../../../src/interfaces";
+
+test("reports/csv - works", async (t) => {
+  const sourceFile = fixtureAsSourceFile("stats/cyclomaticComplexity.ts");
+  const results: StatResults = {};
+  results["path1/file1"] = [];
+  results["path2/file2"] = [];
+  const stat1 = await stat(sourceFile, { threshold: 1 });
+  const stat2 = await stat(sourceFile, { threshold: 100 });
+  if (stat1) {
+    results["path1/file1"].push(stat1);
+  }
+  if (stat2) {
+    results["path2/file2"].push(stat2);
+  }
+  report(results);
+  report(results, { output: "/dev/null" });
+  t.assert(true);
+});

--- a/tests/unit/reports/csv.ts
+++ b/tests/unit/reports/csv.ts
@@ -1,4 +1,6 @@
 import test from "ava";
+import { fileSync } from "tmp";
+import { readFileSync } from "fs";
 import { fixtureAsSourceFile } from "../../util";
 import { stat } from "../../../src/stats/anonInnerLength";
 import { report } from "../../../src/reports/csv";
@@ -18,6 +20,12 @@ test("reports/csv - works", async (t) => {
     results["path2/file2"].push(stat2);
   }
   report(results);
-  report(results, { output: "/dev/null" });
-  t.assert(true);
+  const tempFile = fileSync();
+  report(results, { output: tempFile.name });
+  const expected = `
+"Path","Anonymous inner length"
+"path1/file1",5
+"path2/file2",
+`.trim();
+  t.is(readFileSync(tempFile.name, "utf-8"), expected);
 });

--- a/tests/unit/reports/table.ts
+++ b/tests/unit/reports/table.ts
@@ -1,0 +1,22 @@
+import test from "ava";
+import { fixtureAsSourceFile } from "../../util";
+import { stat } from "../../../src/stats/anonInnerLength";
+import { report } from "../../../src/reports/table";
+import { StatResults } from "../../../src/interfaces";
+
+test("reports/table - works", async (t) => {
+  const sourceFile = fixtureAsSourceFile("stats/cyclomaticComplexity.ts");
+  const results: StatResults = {};
+  results["path1/file1"] = [];
+  results["path2/file2"] = [];
+  const stat1 = await stat(sourceFile, { threshold: 1 });
+  const stat2 = await stat(sourceFile, { threshold: 100 });
+  if (stat1) {
+    results["path1/file1"].push(stat1);
+  }
+  if (stat2) {
+    results["path2/file2"].push(stat2);
+  }
+  report(results);
+  t.assert(true);
+});

--- a/tests/unit/stats/cyclomaticComplexity.ts
+++ b/tests/unit/stats/cyclomaticComplexity.ts
@@ -14,7 +14,7 @@ test("stats/cyclomaticComplexity - counts functions and methods", async (t) => {
   const sourceFile = fixtureAsSourceFile("stats/cyclomaticComplexity.ts");
   const actual = await stat(sourceFile, { threshold: 10 });
   t.assert(actual);
-  t.is(actual?.count, 7);
+  t.is(actual?.count, 11);
 });
 
 test("stats/cyclomaticComplexity - scores based on threshold", async (t) => {

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -1,0 +1,13 @@
+import test from "ava";
+
+import { commonStartsWith, sortPaths } from "../../src/util";
+
+test("util/commonStartsWith - no items", async (t) => {
+  const actual = commonStartsWith(["a/a", "a/b"]);
+  t.is(actual, "a/");
+});
+
+test("util/sortPaths - no items", async (t) => {
+  const actual = sortPaths(["b/b", "a/b", "a/a"]);
+  t.deepEqual(actual, ["a/a", "a/b", "b/b"]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,6 +322,11 @@
   resolved "https://registry.yarnpkg.com/@types/table/-/table-5.0.0.tgz#67c3821138eb41d538c3d9286771c6cdeeac7172"
   integrity sha512-fQLtGLZXor264zUPWI95WNDsZ3QV43/c0lJpR/h1hhLJumXRmHNsrvBfEzW2YMhb0EWCsn4U6h82IgwsajAuTA==
 
+"@types/tmp@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
+  integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -3615,6 +3620,13 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #19

In the following code:

https://github.com/h-o-t/nocuous/blob/c9e3041deec4ba56ec6c0f3489026d42d5eee9a5/src/reports/csv.ts#L42

`row` was getting trimmed by one column too many, since `row` has an
extra "Path" leading column that `headers` don't.